### PR TITLE
perf: use all processors for faster rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "nalgebra",
+ "num_cpus",
  "rand",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ image = "0.23.14"
 indicatif = "0.15.0"
 lazy_static = "1.4.0"
 nalgebra = "0.26.1"
+num_cpus = "1.13.0"
 rand = "0.8.3"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_yaml = "0.8.17"

--- a/src/hittable.rs
+++ b/src/hittable.rs
@@ -1,19 +1,17 @@
-use std::rc::Rc;
-
 use crate::material::Material;
 use crate::ray::Ray;
 use crate::vec3::{Point3, Vec3};
 
-pub(crate) struct HitRecord {
+pub(crate) struct HitRecord<M: Material> {
     p: Point3,
     normal: Vec3,
-    material: Rc<dyn Material>,
+    material: M,
     t: f64,
     front_face: bool,
 }
 
-impl HitRecord {
-    pub(crate) fn new(p: Point3, normal: Vec3, material: Rc<dyn Material>, t: f64) -> Self {
+impl<M: Material> HitRecord<M> {
+    pub(crate) fn new(p: Point3, normal: Vec3, material: M, t: f64) -> Self {
         Self {
             p,
             normal,
@@ -31,7 +29,7 @@ impl HitRecord {
         &self.normal
     }
 
-    pub(crate) fn material(&self) -> &Rc<dyn Material> {
+    pub(crate) fn material(&self) -> &M {
         &self.material
     }
 
@@ -65,6 +63,7 @@ impl HitRecord {
     }
 }
 
-pub(crate) trait Hittable: std::fmt::Debug {
-    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord>;
+pub(crate) trait Hittable {
+    type Material: Material;
+    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord<Self::Material>>;
 }

--- a/src/hittable_list.rs
+++ b/src/hittable_list.rs
@@ -2,22 +2,24 @@ use crate::hittable::{HitRecord, Hittable};
 use crate::ray::Ray;
 
 #[derive(Debug)]
-pub(crate) struct HittableList {
-    objects: Vec<Box<dyn Hittable>>,
+pub(crate) struct HittableList<H: Hittable> {
+    objects: Vec<H>,
 }
 
-impl HittableList {
+impl<H: Hittable> HittableList<H> {
     pub(crate) fn new() -> Self {
         Self { objects: vec![] }
     }
 
-    pub(crate) fn add(&mut self, object: Box<dyn Hittable>) {
+    pub(crate) fn add(&mut self, object: H) {
         self.objects.push(object);
     }
 }
 
-impl Hittable for HittableList {
-    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord> {
+impl<H: Hittable> Hittable for HittableList<H> {
+    type Material = H::Material;
+
+    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord<Self::Material>> {
         let mut temp_rec = None;
         let mut closest_so_far = t_max;
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -7,11 +7,13 @@ use crate::vec3::{
 
 pub(crate) type Scatter = Option<(Ray, Color)>;
 
-pub(crate) trait Material: std::fmt::Debug {
-    fn scatter(&self, r_in: &Ray, rec: &HitRecord, scattered: &Ray) -> Scatter;
+pub(crate) trait Material {
+    fn scatter(&self, r_in: &Ray, rec: &HitRecord<Self>, scattered: &Ray) -> Scatter
+    where
+        Self: std::marker::Sized;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Lambertian {
     albedo: Color,
 }
@@ -23,7 +25,7 @@ impl Lambertian {
 }
 
 impl Material for Lambertian {
-    fn scatter(&self, r_in: &Ray, rec: &HitRecord, _scatteredd: &Ray) -> Scatter {
+    fn scatter(&self, r_in: &Ray, rec: &HitRecord<Self>, _scatteredd: &Ray) -> Scatter {
         let mut scatter_direction = rec.normal() + random_unit_vector();
 
         // Catch degenerate scatter direction
@@ -38,7 +40,7 @@ impl Material for Lambertian {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Metal {
     albedo: Color,
     fuzz: f64,
@@ -54,7 +56,7 @@ impl Metal {
 }
 
 impl Material for Metal {
-    fn scatter(&self, r_in: &Ray, rec: &HitRecord, _scatter: &Ray) -> Scatter {
+    fn scatter(&self, r_in: &Ray, rec: &HitRecord<Self>, _scatter: &Ray) -> Scatter {
         let reflected = reflect(&unit_vector(r_in.direction()), rec.normal());
 
         // The book has this surrounded by something like:
@@ -76,7 +78,7 @@ impl Material for Metal {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Dielectric {
     ir: f64, // Index of refraction
 }
@@ -95,7 +97,7 @@ impl Dielectric {
 }
 
 impl Material for Dielectric {
-    fn scatter(&self, r_in: &Ray, rec: &HitRecord, _scattered: &Ray) -> Scatter {
+    fn scatter(&self, r_in: &Ray, rec: &HitRecord<Self>, _scattered: &Ray) -> Scatter {
         let attenuation = Color::new(1.0, 1.0, 1.0);
         let refraction_ratio = if *rec.front_face() {
             1.0 / self.ir

--- a/src/moving_sphere.rs
+++ b/src/moving_sphere.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use core::fmt::Debug;
 
 use crate::hittable::{HitRecord, Hittable};
 use crate::material::Material;
@@ -7,19 +7,19 @@ use crate::scene_loader::StartEndPair;
 use crate::vec3::{length_squared, Point3};
 
 #[derive(Debug)]
-pub(crate) struct MovingSphere {
+pub(crate) struct MovingSphere<M: Material + Debug> {
     center: StartEndPair<Point3>,
     time: StartEndPair<f64>,
     radius: f64,
-    material: Rc<dyn Material>,
+    material: M,
 }
 
-impl MovingSphere {
+impl<M: Material + Debug> MovingSphere<M> {
     pub(crate) fn new(
         center: StartEndPair<Point3>,
         time: StartEndPair<f64>,
         radius: f64,
-        material: Rc<dyn Material>,
+        material: M,
     ) -> Self {
         Self {
             center,
@@ -36,8 +36,10 @@ impl MovingSphere {
     }
 }
 
-impl Hittable for MovingSphere {
-    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord> {
+impl<M: Material + Clone + Debug> Hittable for MovingSphere<M> {
+    type Material = M;
+
+    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord<Self::Material>> {
         let oc = r.origin() - self.center(r.time());
         let a = length_squared(r.direction());
         let half_b = oc.dot(r.direction());

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use core::fmt::Debug;
 
 use crate::hittable::{HitRecord, Hittable};
 use crate::material::Material;
@@ -6,14 +6,14 @@ use crate::ray::Ray;
 use crate::vec3::{length_squared, Point3};
 
 #[derive(Debug)]
-pub(crate) struct Sphere {
+pub(crate) struct Sphere<M: Material + Debug> {
     center: Point3,
     radius: f64,
-    material: Rc<dyn Material>,
+    material: M,
 }
 
-impl Sphere {
-    pub(crate) fn new(center: Point3, radius: f64, material: Rc<dyn Material>) -> Self {
+impl<M: Material + Debug> Sphere<M> {
+    pub(crate) fn new(center: Point3, radius: f64, material: M) -> Self {
         Self {
             center,
             radius,
@@ -22,8 +22,10 @@ impl Sphere {
     }
 }
 
-impl Hittable for Sphere {
-    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord> {
+impl<M: Material + Clone + Debug> Hittable for Sphere<M> {
+    type Material = M;
+
+    fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord<M>> {
         let oc = r.origin() - self.center;
         let a = length_squared(r.direction());
         let half_b = oc.dot(r.direction());


### PR DESCRIPTION
This is more of a suggestion. I had to break many things to make it compile.

Some timing results:

Before:

```
cargo run --release -- -f scene.yml  87,48s user 0,04s system 99% cpu 1:27,52 total
cargo run --release -- -f scene.yml  87,22s user 0,12s system 99% cpu 1:27,55 total
cargo run --release -- -f scene.yml  88,17s user 0,08s system 99% cpu 1:28,26 total
```

After:

```
cargo run --release -- -f scene.yml  135,41s user 0,81s system 690% cpu 19,724 total
cargo run --release -- -f scene.yml  136,18s user 0,84s system 704% cpu 19,452 total
cargo run --release -- -f scene.yml  135,47s user 0,77s system 716% cpu 19,013 total
```